### PR TITLE
Fix for 1-second-bug

### DIFF
--- a/Tomate/Focus/TimerView.swift
+++ b/Tomate/Focus/TimerView.swift
@@ -167,8 +167,6 @@ final class TimerView: UIView {
   
   func updateTimer() {
     
-    //TODO: Fix 1-second-bug (idle timer shows 1 second when not in remaining mode)
-    
     var percentage: CGFloat
     var dummyInt: Int
     if !showRemaining {
@@ -188,7 +186,7 @@ final class TimerView: UIView {
       
     }
     
-    if !showRemaining {
+    if durationInSeconds > 0 && !showRemaining {
       durationInSeconds = maxValue - durationInSeconds
     }
     let seconds = Int(durationInSeconds.truncatingRemainder(dividingBy: 60))


### PR DESCRIPTION
Not sure if it’s really more of a workaround, but it works.
When the timer is idle and you tap it to switch between remaining and
not remaining mode, a second used to appear out of nowhere. With this
fix, the second no longer appears, but the timer stays at 0:00.